### PR TITLE
Potential fix for code scanning alert no. 240: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - v3
 name: release-please
+permissions:
+  contents: read
+  packages: write
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jm33-m0/emp3r0r/security/code-scanning/240](https://github.com/jm33-m0/emp3r0r/security/code-scanning/240)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's functionality (e.g., releasing software, uploading assets), the following permissions are likely required:
- `contents: read` for reading repository contents.
- `packages: write` for uploading assets.
- `pull-requests: write` for interacting with pull requests (if applicable).

The `permissions` block should be added at the root level of the workflow to apply to all jobs. If specific jobs require different permissions, additional `permissions` blocks can be added within those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
