### PR TITLE
bug fix: correct EUID conditional syntax in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -122,7 +122,7 @@ cd emp3r0r-source/core || error "Failed to enter core directory"
 warn "Building and installing emp3r0r $tag (this may take a while)..."
 # build.sh will handle zig and other internal dependencies
 export TAG="$tag"
-if "$EUID" -eq 0; then
+if [ "$EUID" -eq 0 ]; then
   ./build.sh --install || error "Build and installation failed"
 else
   sudo ./build.sh --install || error "Build and installation failed"


### PR DESCRIPTION
The EUID privilege check was missing square brackets, causing bash to interpret the value of `$EUID` (e.g. 0 or 1000) as a command:
```bash
if "$EUID" -eq 0; then   # broken
```

This makes installation always fail at the build step with: 
```bash
bash: line 125: 0: command not found
```

Fix by wrapping in `[ ]` for a proper integer comparison: 
```bash
if [ "$EUID" -eq 0 ]; then
```